### PR TITLE
Fix the HTML structure in the README.

### DIFF
--- a/packages/web-component/README.md
+++ b/packages/web-component/README.md
@@ -38,9 +38,9 @@ Then you can use them.
 
 ```html
 <window-panel-group>
-  <window-panel min="130px" max="400px" />
-  <window-panel-resizer />
-  <window-panel min="130px" />
+  <window-panel min="130px" max="400px"></window-panel>
+  <window-panel-resizer></window-panel-resizer>
+  <window-panel min="130px"></<window-panel>
 </window-panel-group>
 ```
 


### PR DESCRIPTION
The example HTML didn't close three tags, which would have resulted in incorrect nesting of the elements:

- window-panel-group
  - window-panel
    - window-panel-resizer
      - window-panel

With this change, the structure is:

- window-panel-group
  - window-panel
  - window-panel-resizer
  - window-panel