### PR TITLE
fix: parse stored default value to Big

### DIFF
--- a/packages/react/src/ReactWindowSplitter.stories.tsx
+++ b/packages/react/src/ReactWindowSplitter.stories.tsx
@@ -672,7 +672,7 @@ export function ConditionalPanelComplex() {
 
 export function WithDefaultWidth() {
   return (
-    <PanelGroup style={{ height: "400px" }}>
+    <PanelGroup style={{ height: "400px" }} autosaveId="with-default-width">
       <Panel style={{ backgroundColor: "#333366" }} />
       <PanelResizer size="3px" />
       {/* I expected the right panel to be 100px wide */}

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -402,6 +402,10 @@ export function prepareSnapshot(snapshot: GroupMachineContextValue) {
       item.collapsedSize.value = new Big(item.collapsedSize.value);
       item.min.value = new Big(item.min.value);
 
+      if (item.default) {
+        item.default.value = new Big(item.default.value);
+      }
+
       if (item.max && item.max !== "1fr") {
         item.max.value = new Big(item.max.value);
       }

--- a/packages/state/src/utils.test.ts
+++ b/packages/state/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe } from "vitest";
+import { expect, test, describe, assert } from "vitest";
 
 import {
   getUnitPercentageValue,
@@ -6,6 +6,8 @@ import {
   initializePanel,
   getCursor,
   initializePanelHandleData,
+  prepareSnapshot,
+  type Item,
 } from "./index.js";
 import Big from "big.js";
 import { createActor } from "./test-utils.js";
@@ -188,5 +190,30 @@ describe("initializePanelHandleData", () => {
         "type": "handle",
       }
     `);
+  });
+});
+
+describe('prepareSnapshot', () => {
+  test('converts sizes to Big', () => {
+    const item: Item = initializePanel({ id: 'panel-1', min: '100px', max: '300px', default: '200px' });
+
+    prepareSnapshot({
+      size: { width: 500, height: 300 },
+      items: [item, initializePanel({ id: 'panel-2', min: '100px' })],
+      groupId: 'group-1',
+      orientation: 'horizontal',
+      dragOvershoot: new Big(0),
+    });
+
+    expect(item.currentValue.value).toBeInstanceOf(Big);
+    expect(item.collapsedSize.value).toBeInstanceOf(Big);
+
+    expect(item.min.value).toBeInstanceOf(Big);
+
+    assert(typeof item.max === 'object');
+    expect(item.max.value).toBeInstanceOf(Big);
+
+    assert(typeof item.default === 'object');
+    expect(item.default.value).toBeInstanceOf(Big);
   });
 });


### PR DESCRIPTION
Hey 👋🏻

Noticed an issue when using this lib, where it errors out when using a stored snapshot that contains a panel with a default value. Here's a video of me reproducing it:

https://github.com/user-attachments/assets/7f3dde5e-d666-4904-b822-755c17e93564

Also created a repro [here](https://codesandbox.io/p/sandbox/8rfkjy?file=%2Fsrc%2FApp.tsx) (reload the preview after it renders). There might be something else going on, because the error did not happen every time, but I couldn't figure out why.

Thanks for the lib, it's awesome!