### PR TITLE
fix: Prevent React panel group data from being saved to local storage when autosaveId is not set

### DIFF
--- a/packages/react/src/ReactWindowSplitter.tsx
+++ b/packages/react/src/ReactWindowSplitter.tsx
@@ -338,7 +338,7 @@ const PanelGroupImpl = React.forwardRef<
 >(function PanelGroupImpl(
   {
     autosaveId,
-    autosaveStrategy = "localStorage",
+    autosaveStrategy = autosaveId ? "localStorage" : undefined,
     snapshot: snapshotProp,
     initialItems,
     shiftAmount,


### PR DESCRIPTION
Panel group data with the auto-generated id is being saved to local storage even when `autosaveId` is not set.
This simple fix makes sure the default `autosaveStrategy` is only set if we're also passing the `autosaveId` . 


![image](https://github.com/user-attachments/assets/d6f32104-7873-4f7b-b710-719e6e697171)
